### PR TITLE
marshmallow: custom PersistentIdentifier field

### DIFF
--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/marshmallow/json.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/marshmallow/json.py
@@ -4,14 +4,9 @@
 from __future__ import absolute_import, print_function
 
 from invenio_records_rest.schemas import StrictKeysMixin
-from invenio_records_rest.schemas.fields import DateString, SanitizedUnicode
+from invenio_records_rest.schemas.fields import DateString, \
+    PersistentIdentifier, SanitizedUnicode
 from marshmallow import fields, missing, validate
-
-
-def get_{{ cookiecutter.pid_name }}(obj, context):
-    """Get record id."""
-    pid = context.get('pid')
-    return pid.pid_value if pid else missing
 
 
 class PersonIdsSchemaV1(StrictKeysMixin):
@@ -39,9 +34,7 @@ class MetadataSchemaV1(StrictKeysMixin):
         pid = self.context.get('pid')
         return pid.pid_value if pid else missing
 
-    {{ cookiecutter.pid_name }} = fields.Function(
-        serialize=get_{{ cookiecutter.pid_name }},
-        deserialize=get_{{ cookiecutter.pid_name }})
+    {{ cookiecutter.pid_name }} = PersistentIdentifier()
     title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
     keywords = fields.Nested(fields.Str(), many=True)
     publication_date = DateString()
@@ -56,6 +49,4 @@ class RecordSchemaV1(StrictKeysMixin):
     revision = fields.Integer(dump_only=True)
     updated = fields.Str(dump_only=True)
     links = fields.Dict(dump_only=True)
-    id = fields.Function(
-        serialize=get_{{ cookiecutter.pid_name }},
-        deserialize=get_{{ cookiecutter.pid_name }})
+    id = PersistentIdentifier()


### PR DESCRIPTION
* ADDs PersistentIdentifier field to handle loading and serializing
  persistent identifiers of outgoing records or incoming data.

Addresses #30 

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>