### PR TITLE
schemas: custom Nested class for validation errors

### DIFF
--- a/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/marshmallow/json.py
+++ b/{{cookiecutter.project_shortname}}/{{cookiecutter.package_name}}/marshmallow/json.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, print_function
 
-from invenio_records_rest.schemas import StrictKeysMixin
+from invenio_records_rest.schemas import Nested, StrictKeysMixin
 from invenio_records_rest.schemas.fields import DateString, SanitizedUnicode
 from marshmallow import fields, missing, validate
 
@@ -45,7 +45,7 @@ class MetadataSchemaV1(StrictKeysMixin):
     title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
     keywords = fields.Nested(fields.Str(), many=True)
     publication_date = DateString()
-    contributors = fields.Nested(ContributorSchemaV1, many=True, required=True)
+    contributors = Nested(ContributorSchemaV1, many=True, required=True)
 
 
 class RecordSchemaV1(StrictKeysMixin):


### PR DESCRIPTION
* ADD a Nested class to override the _validate_missing method and
  show the first missing field in the errors.

Closes https://github.com/inveniosoftware/invenio-records-rest/issues/223

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>